### PR TITLE
Max DevApp and general WebServer work

### DIFF
--- a/pithy_/pithy/web/dev/controls.py
+++ b/pithy_/pithy/web/dev/controls.py
@@ -1,18 +1,22 @@
 # Dedicated to the public domain under CC0: https://creativecommons.org/publicdomain/zero/1.0/.
 
-'Developer reference page demonstrating all standard HTML form controls with htmx.'
+'Developer reference page demonstrating all standard HTML form controls with and without htmx.'
 
 from typing import Any
 
 from pithy.default import Default
-from pithy.html import A, Div, Form, Input, Label, Li, Ol, Select, Span, Sup, TextArea
+from pithy.html import A, Div, Form, Input, Label, Li, Ol, Select, Span, Strong, Sup, TextArea
 from pithy.markup import MuChild, Present
 
 
-def controls_form(values:dict[str,str]|None=None) -> Div:
+def posted_values(values:dict[str,str|list[str]]|None=None) -> Div:
+  return Div(style='background-color: #f0f4ff; padding: 1rem;', *[Div(Strong(k), f': {v}') for k, v in (values or {}).items()], id='posted-values')
+
+
+def controls_form(values:dict[str,str|list[str]]|None=None) -> Div:
   'Return a Form demonstrating all standard interactive HTML form controls, optionally populated with `values`.'
 
-  vals:dict[str,str] = values or {}
+  vals:dict[str,str|list[str]] = values or {}
   div = Div()
   form = div.append(Form(cl='grid', method='post', enctype='multipart/form-data'))
 
@@ -52,13 +56,13 @@ def controls_form(values:dict[str,str]|None=None) -> Div:
     placeholder='Choose...', value=vals.get('select')))
 
   _row('select multiple',
-    Select(name='select-multiple', multiple='').options(['Option A', 'Option B', 'Option C'],
-      value=vals.get('select-multiple')))
+    Select(name='select_multiple', multiple='').options(['Option A', 'Option B', 'Option C'],
+      value=vals.get('select_multiple')))
 
   _row('date', Input(type='date', name='date', **_v('date')))
   _row('time', Input(type='time', name='time', **_v('time')))
-  _row('datetime-local', Span(cl='flex-row gap-1ch',
-    _=[Input(type='datetime-local', name='datetime-local', **_v('datetime-local')), ftnt(1)]))
+  _row('datetime_local', Span(cl='flex-row gap-1ch',
+    _=[Input(type='datetime-local', name='datetime_local', **_v('datetime_local')), ftnt(1)]))
   _row('month', Span(cl='flex-row gap-1ch', _=[Input(type='month', name='month', **_v('month')), ftnt(1)]))
   _row('week', Span(cl='flex-row gap-1ch', _=[Input(type='week', name='week', **_v('week')), ftnt(1)]))
 
@@ -83,3 +87,89 @@ def controls_form(values:dict[str,str]|None=None) -> Div:
   )]))
 
   return div
+
+
+def controls_htmx() -> Div:
+  'Return a Form demonstrating all standard interactive HTML form controls, with HTMX.'
+
+  outer = Div()
+  div = outer.append(Div(cl='form_grid'))
+  url = '/controls-htmx/update'
+  _htmx_tags:dict[str,Any] = {'hx_target': '#posted-values', 'hx_swap': 'beforeend'}
+
+  def _row(label_text:str, *controls:MuChild) -> None:
+    'Append a label and control(s) to the form grid.'
+    for control in controls:
+      div.append(Label(_=label_text))
+      div.append(control)
+
+  def ftnt(i:int) -> Sup:
+    'Footnote link.'
+    return Sup(_=['[', A(href=f'#fn{i}', _=i), ']'])
+
+  _row('text', Input(type='text', name='text', placeholder='text input', hx_trigger="change", hx_post=url, **_htmx_tags))
+  _row('email', Input(type='email', name='email', placeholder='user@example.com', hx_trigger="change", hx_post=url, **_htmx_tags))
+  _row('number', Input(type='number', name='number', placeholder='0', hx_trigger="change", hx_post=url, **_htmx_tags))
+  _row('password', Input(type='password', name='password', placeholder='password', hx_trigger="change", hx_post=url, **_htmx_tags))
+  _row('tel', Input(type='tel', name='tel', placeholder='+1-555-555-5555', hx_trigger="change", hx_post=url, **_htmx_tags))
+  _row('url', Input(type='url', name='url', placeholder='https://example.com', hx_trigger="change", hx_post=url, **_htmx_tags))
+  _row('search', Input(type='search', name='search', placeholder='search', hx_trigger="change", hx_post=url, **_htmx_tags))
+  _row('textarea', TextArea(name='textarea', placeholder='Enter text here...', rows='4', cols='40', hx_trigger="change", hx_post=url, **_htmx_tags))
+
+  # Checkboxes must be wrapped in a <form> so HTMX uses form serialization, which omits the field when unchecked.
+  # Without a form ancestor, HTMX reads input.value, which is always "on" regardless of checked state.
+  _row('checkbox', Span(cl='flex-row gap-1ch',
+    _=[Form(hx_post=url, hx_trigger='change', **_htmx_tags,
+      _=Input(type='checkbox', name='checkbox')), ftnt(1)]))
+
+  _row('radio', Span(cl='flex-row gap-1ch',
+    _=[
+      Label(Input(type='radio', name='radio', value='a', hx_trigger='change', hx_post=url, **_htmx_tags), 'Option A'),
+      Label(Input(type='radio', name='radio', value='b', hx_trigger='change', hx_post=url, **_htmx_tags), 'Option B'),
+    ]))
+
+  _row('select', Select(name='select', hx_trigger='change', hx_post=url, **_htmx_tags).options(['Option A', 'Option B', 'Option C'],
+    placeholder='Choose...'))
+
+  # Select-multiple inputs must be wrapped in a <form> so HTMX uses form serialization, which captures all selected values.
+  # Without a form ancestor, HTMX reads input.value, which returns only the first selected option rather than iterating input.selectedOptions.
+  _row('select multiple', Span(cl='flex-row gap-1ch',
+    _=[Form(hx_post=url, hx_trigger='change delay:500ms', **_htmx_tags,
+      _=Select(name='select_multiple', multiple='').options(['Option A', 'Option B', 'Option C'])), ftnt(2)]))
+
+  _row('date', Input(type='date', name='date', hx_trigger='change', hx_post=url, **_htmx_tags))
+  _row('time', Input(type='time', name='time', hx_trigger='change', hx_post=url, **_htmx_tags))
+  _row('datetime_local', Span(cl='flex-row gap-1ch',
+    _=[Input(type='datetime-local', name='datetime_local', hx_trigger='change', hx_post=url, **_htmx_tags), ftnt(3)]))
+  _row('month', Span(cl='flex-row gap-1ch', _=[Input(type='month', name='month', hx_trigger='change', hx_post=url, **_htmx_tags), ftnt(3)]))
+  _row('week', Span(cl='flex-row gap-1ch', _=[Input(type='week', name='week', hx_trigger='change', hx_post=url, **_htmx_tags), ftnt(3)]))
+
+
+  _row('color', Input(type='color', name='color', hx_trigger='change', hx_post=url, **_htmx_tags))
+
+  _row('range', Input(type='range', name='range', min='0', max='10', hx_trigger='input', hx_post=url, **_htmx_tags))
+
+
+  # HTMX reads .value off the triggering element, except when it finds a <form> ancestor,
+  # in which case it uses the JS FormData API (which handles checkboxes, files, etc. correctly).
+  #
+  # File inputs must be wrapped in a <form> because only FormData reads input.files (the actual
+  # binary file handle); without it, HTMX falls back to input.value, which is just a fake path string.
+  _row('file', Span(cl='flex-row gap-1ch',
+    _=[Form(hx_encoding='multipart/form-data', hx_post=url, hx_trigger='change', **_htmx_tags,
+      _=Input(type='file', name='file')), ftnt(4)]))
+
+  outer.append(Div(cl='flex-col font-small', _=['Notes:',
+  Ol(
+    Li(id='fn1', _='Checkboxes must be wrapped in a <form> so HTMX uses form serialization, which omits the field when'
+      ' unchecked. Without a form ancestor, HTMX reads input.value, which is always "on" regardless of checked state.'),
+    Li(id='fn2', _='Select-multiple inputs must be wrapped in a <form> so HTMX uses form serialization, which captures'
+      ' all selected values. Without a form ancestor, HTMX reads input.value, which returns only the first selected'
+      ' option rather than iterating input.selectedOptions.'),
+    Li(id='fn3', _='Desktop Safari falls back to a plain text field for datetime-local, month, and week input types.'
+      ' Values entered in the text fallback are not validated by the browser.'),
+    Li(id='fn4', _='File inputs must be wrapped in a <form> so HTMX uses the FormData API, which reads the actual file'
+      ' bytes via input.files. Without a form ancestor, HTMX falls back to input.value, which is a fake path string.'),
+  )]))
+
+  return outer

--- a/pithy_/pithy/web/dev/routes.py
+++ b/pithy_/pithy/web/dev/routes.py
@@ -1,16 +1,18 @@
 # Dedicated to the public domain under CC0: https://creativecommons.org/publicdomain/zero/1.0/.
 
-from ...html import H1, Main
+import datetime as dt
+
+from ...html import Div, H1, Main, Strong
 from ..endpoint import Endpoint
-from ..request import Request
+from ..request import Request, UploadedFile
 from ..response import HtmlResponse, Response
 from ..static import pithy_web_static_dir_path
-from .controls import controls_form
+from .controls import controls_form, controls_htmx, posted_values
 from .responses import page_html
 
 
 pithy_css_path = pithy_web_static_dir_path() + '/pithy.css'
-
+max_body_bytes = 64 * 1024
 
 class IndexHtml(Endpoint):
   'Returns a simple HTML page.'
@@ -22,12 +24,92 @@ class IndexHtml(Endpoint):
 
 class DevControls(Endpoint):
   'Returns a form for testing controls.'
+  max_body_bytes = 64 * 1024
+
+  text: str | None
+  email: str | None
+  hidden: str | None
+  number: str | None
+  password: str | None
+  tel: str | None
+  url: str | None
+  search: str | None
+  textarea: str | None
+  checkbox: str | None
+  radio: str | None
+  select: str | None
+  date: str | None
+  time: str | None
+  color: str | None
+  range: str | None
+  submit: str | None
+  week: str | None
+  month: str | None
+  datetime_local: str | None
+  select_multiple: list[str] | None
+  file: UploadedFile | None
+
+  def _items(self) -> dict[str, str | list[str]]:
+    return {name: v for name in self._fields if (v := getattr(self, name))}
 
   def handle_request(self, request:Request) -> Response:
     main = Main(
       H1('Dev Controls'),
-      controls_form())
+      posted_values(self._items()),
+      controls_form(self._items()))
     return page_html(title='Dev Controls', main=main)
+
+
+
+class DevControlsHtmx(Endpoint):
+  'Returns a page of testing controls as HTMX elements.'
+  max_body_bytes = max_body_bytes
+
+  def handle_request(self, request:Request) -> Response:
+    main = Main(
+      H1('Dev Controls'),
+      posted_values(),
+      controls_htmx())
+    return page_html(title='Dev Controls', main=main)
+
+
+
+class ControlsHtmxUpdate(Endpoint):
+  'Handles any field update from the HTMX DevControls page.'
+  max_body_bytes = max_body_bytes
+
+  text: str | None
+  email: str | None
+  number: str | None
+  password: str | None
+  tel: str | None
+  url: str | None
+  search: str | None
+  textarea: str | None
+  checkbox: str | None
+  radio: str | None
+  select: str | None
+  date: dt.date | None
+  time: dt.time | None
+  datetime_local: dt.datetime | None
+  month: str | None
+  week: str | None
+  color: str | None
+  range: int | None
+  select_multiple: list[str] | None
+  file: UploadedFile | None
+
+  def handle_request(self, request:Request) -> Response:
+    for name in self._fields:
+      val = getattr(self, name)
+      if val is None:
+        continue
+      display = name.replace('_', '-')
+      if isinstance(val, UploadedFile):
+        return HtmlResponse(body=Div(Strong(display), f': {val.filename} ({len(val.data)} bytes)'))
+      return HtmlResponse(body=Div(Strong(display), f': {val}'))
+    return HtmlResponse(body=Div())
+
 
 
 class PithyCss(Endpoint):
@@ -43,5 +125,7 @@ class PithyCss(Endpoint):
 routes:dict[str,type[Endpoint]] = {
   '/': IndexHtml,
   '/controls': DevControls,
+  '/controls-htmx': DevControlsHtmx,
+  '/controls-htmx/update': ControlsHtmxUpdate,
   '/pithy.css': PithyCss,
 }


### PR DESCRIPTION
_Commits are organized by work done, sequentially. Here's the high-level of what each one does:_

**1. pithy.web: add UploadedFile and list[T] field support, multi-value params, unit tests**
- Does upfront work on web server to allow for UploadedFile logic, lists, and unit tests for this. These are the logic changes that are needed for the following commits that work on DevApp.

**2. pithy.web.dev: build out HTML and HTMX controls pages**

- Builds a /controls-htmx page that uses per-control endpoints + HTMX, shows ergonomic tradoffs of certain things in HTMX
- Footnotes for weird stuff

**3. pithy.web.dev: single HTMX endpoint**

- Optional alternative to the per-control endpoint. this shows what it looks like with just one handler that special cases.

**4. pithy.transtruct: allow prefigures to intercept primitives; stricter str conversion)[pithy.transtruct: allow prefigures to intercept primitives; stricter str conversion**

- Does prep work on Transtructor module that is necessary for the integration with web server

**5. pithy.web.endpoint: refactor to use Transtructor**

- Does the integration work to replace converter logic to use `Transtructor`




