### PR TITLE
Delegate field conversion to Transtructor

### DIFF
--- a/pithy_/pithy/transtruct.py
+++ b/pithy_/pithy/transtruct.py
@@ -122,10 +122,16 @@ class Transtructor:
     This means that the transtructor instance must not be further customized after the first call to this method.
     '''
 
-    try: return primitive_transtructors[desired_type] # type: ignore[return-value]
-    except KeyError: pass
-
     prefigure_fn = self.prefigure_fn_for(desired_type)
+
+    try: primitive = primitive_transtructors[desired_type] # type: ignore[index]
+    except KeyError: pass
+    else:
+      if not prefigure_fn: return primitive # type: ignore[return-value]
+      def transtruct_primitive_with_prefigure(val:Input, ctx:Ctx) -> Desired:
+        val = prefigure_fn(desired_type, val, ctx)
+        return primitive(val, ctx) # type: ignore[return-value]
+      return transtruct_primitive_with_prefigure
 
     origin = get_origin(desired_type)
     type_args = get_args(desired_type)
@@ -263,6 +269,7 @@ class Transtructor:
       el_ttor = self.transtructor_for(el_type)
 
       def transtruct_collection(val:Input, ctx:Ctx) -> Desired:
+        if prefigure_fn: val = prefigure_fn(desired_type, val, ctx)
         return origin(el_ttor(e, ctx) for e in val)
 
       return transtruct_collection
@@ -436,7 +443,8 @@ def transtruct_object(v:Input, ctx:Ctx) -> object:
 
 
 def transtruct_str(v:Input, ctx:Ctx) -> str:
-  return str(v)
+  if isinstance(v, str): return v
+  raise ValueError(f'Expected str; received {type(v).__name__} {v!r}.')
 
 
 def transtruct_type(v:Any, ctx:Ctx) -> type:

--- a/pithy_/pithy/transtruct.ut.py
+++ b/pithy_/pithy/transtruct.ut.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from typing import NamedTuple
 
 from pithy.transtruct import Transtructor
-from utest import utest
+from utest import utest, utest_exc
 
 
 ttor = Transtructor()
@@ -22,8 +22,8 @@ utest(0.0, ttor.transtruct, float, 0)
 utest(0.0, ttor.transtruct, float, '0.0')
 
 utest('0', ttor.transtruct, str, '0')
-utest('0', ttor.transtruct, str, 0)
-utest('0.0', ttor.transtruct, str, 0.0)
+utest_exc(ValueError, ttor.transtruct, str, 0)
+utest_exc(ValueError, ttor.transtruct, str, 0.0)
 
 utest(1, ttor.transtruct, object, 1) # object passes any value through.
 
@@ -74,3 +74,23 @@ utest(Counter({'a':1}), ttor.transtruct, Counter[str], {'a':'1'})
 utest(0, ttor.transtruct, int|str|None, 0)
 utest('0', ttor.transtruct, int|str|None, '0')
 utest(None, ttor.transtruct, int|str|None, None)
+
+
+# Prefigure tests.
+
+ptor = Transtructor()
+
+# Change 1: prefigure intercepts primitive types.
+
+@ptor.prefigure(str)
+def _strict_str(cls:type, val:object, ctx:object) -> str:
+  'Reject non-strings rather than coercing.'
+  if not isinstance(val, str): raise TypeError(f'Expected str, got {type(val).__name__!r}.')
+  return val
+
+utest('hello', ptor.transtruct, str, 'hello')        # str passes through.
+utest_exc(TypeError, ptor.transtruct, str, 42)        # int rejected by prefigure.
+utest_exc(TypeError, ptor.transtruct, str, 3.14)      # float rejected by prefigure.
+
+utest(['a', 'b'], ptor.transtruct, list[str], ['a', 'b'])   # list[str] with valid elements.
+utest_exc(TypeError, ptor.transtruct, list[str], ['a', 1])  # int element rejected by str prefigure.

--- a/pithy_/pithy/web/dev/controls.py
+++ b/pithy_/pithy/web/dev/controls.py
@@ -1,18 +1,21 @@
 # Dedicated to the public domain under CC0: https://creativecommons.org/publicdomain/zero/1.0/.
 
-'Developer reference page demonstrating all standard HTML form controls with htmx.'
+'Developer reference page demonstrating all standard HTML form controls with and without htmx.'
 
 from typing import Any
 
 from pithy.default import Default
-from pithy.html import A, Div, Form, Input, Label, Li, Ol, Select, Span, Sup, TextArea
+from pithy.html import A, Div, Form, Input, Label, Li, Ol, Select, Span, Strong, Sup, TextArea
 from pithy.markup import MuChild, Present
 
 
-def controls_form(values:dict[str,str]|None=None) -> Div:
+def posted_values(values:dict[str,str|list[str]]|None=None) -> Div:
+  return Div(style='background-color: #f0f4ff; padding: 1rem;', *[Div(Strong(k), f': {v}') for k, v in (values or {}).items()], id='posted-values')
+
+def controls_form(values:dict[str, str | list[str]]|None=None) -> Div:
   'Return a Form demonstrating all standard interactive HTML form controls, optionally populated with `values`.'
 
-  vals:dict[str,str] = values or {}
+  vals:dict[str, str | list[str]] = values or {}
   div = Div()
   form = div.append(Form(cl='grid', method='post', enctype='multipart/form-data'))
 
@@ -52,13 +55,13 @@ def controls_form(values:dict[str,str]|None=None) -> Div:
     placeholder='Choose...', value=vals.get('select')))
 
   _row('select multiple',
-    Select(name='select-multiple', multiple='').options(['Option A', 'Option B', 'Option C'],
+    Select(name='select_multiple', multiple='').options(['Option A', 'Option B', 'Option C'],
       value=vals.get('select-multiple')))
 
   _row('date', Input(type='date', name='date', **_v('date')))
   _row('time', Input(type='time', name='time', **_v('time')))
-  _row('datetime-local', Span(cl='flex-row gap-1ch',
-    _=[Input(type='datetime-local', name='datetime-local', **_v('datetime-local')), ftnt(1)]))
+  _row('datetime_local', Span(cl='flex-row gap-1ch',
+    _=[Input(type='datetime-local', name='datetime_local', **_v('datetime_local')), ftnt(1)]))
   _row('month', Span(cl='flex-row gap-1ch', _=[Input(type='month', name='month', **_v('month')), ftnt(1)]))
   _row('week', Span(cl='flex-row gap-1ch', _=[Input(type='week', name='week', **_v('week')), ftnt(1)]))
 
@@ -83,3 +86,88 @@ def controls_form(values:dict[str,str]|None=None) -> Div:
   )]))
 
   return div
+
+def controls_htmx() -> Div:
+  'Return a Form demonstrating all standard interactive HTML form controls, with HTMX.'
+
+  div = Div(cl='form_grid')
+  _htmx_tags:dict[str,Any] = {'hx_target': '#posted-values', 'hx_swap': 'beforeend'}
+
+
+  def _row(label_text:str, *controls:MuChild) -> None:
+    'Append a label and control(s) to the form grid.'
+    for control in controls:
+      div.append(Label(_=label_text))
+      div.append(control)
+
+  def ftnt(i:int) -> Sup:
+    'Footnote link.'
+    return Sup(_=['[', A(href=f'#fn{i}', _=i), ']'])
+
+  _row('text', Input(type='text', name='text', placeholder='text input', hx_trigger="change", hx_post='/controls-htmx/text', **_htmx_tags))
+  _row('email', Input(type='email', name='email', placeholder='user@example.com', hx_trigger="change", hx_post='/controls-htmx/email', **_htmx_tags))
+  _row('number', Input(type='number', name='number', placeholder='0', hx_trigger="change", hx_post='/controls-htmx/number', **_htmx_tags))
+  _row('password', Input(type='password', name='password', placeholder='password', hx_trigger="change", hx_post='/controls-htmx/password', **_htmx_tags))
+  _row('tel', Input(type='tel', name='tel', placeholder='+1-555-555-5555', hx_trigger="change", hx_post='/controls-htmx/tel', **_htmx_tags))
+  _row('url', Input(type='url', name='url', placeholder='https://example.com', hx_trigger="change", hx_post='/controls-htmx/url', **_htmx_tags))
+  _row('search', Input(type='search', name='search', placeholder='search', hx_trigger="change", hx_post='/controls-htmx/search', **_htmx_tags))
+  _row('textarea', TextArea(name='textarea', placeholder='Enter text here...', rows='4', cols='40', hx_trigger="change", hx_post='/controls-htmx/textarea', **_htmx_tags))
+
+  # Checkboxes must be wrapped in a <form> so HTMX uses form serialization, which omits the field when unchecked.
+  # Without a form ancestor, HTMX reads input.value, which is always "on" regardless of checked state.
+  _row('checkbox', Span(cl='flex-row gap-1ch',
+    _=[Form(hx_post='/controls-htmx/checkbox', hx_trigger='change', **_htmx_tags,
+      _=Input(type='checkbox', name='checkbox')), ftnt(1)]))
+
+  _row('radio', Span(cl='flex-row gap-1ch',
+    _=[
+      Label(Input(type='radio', name='radio', value='a', hx_trigger='change', hx_post='/controls-htmx/radio', **_htmx_tags), 'Option A'),
+      Label(Input(type='radio', name='radio', value='b', hx_trigger='change', hx_post='/controls-htmx/radio', **_htmx_tags), 'Option B'),
+    ]))
+
+  _row('select', Select(name='select', hx_trigger='change', hx_post='/controls-htmx/select', **_htmx_tags).options(['Option A', 'Option B', 'Option C'],
+    placeholder='Choose...'))
+
+  # Select-multiple inputs must be wrapped in a <form> so HTMX uses form serialization, which captures all selected values.
+  # Without a form ancestor, HTMX reads input.value, which returns only the first selected option rather than iterating input.selectedOptions.
+  _row('select multiple', Span(cl='flex-row gap-1ch',
+    _=[Form(hx_post='/controls-htmx/select-multiple', hx_trigger='change delay:500ms', **_htmx_tags,
+      _=Select(name='select_multiple', multiple='').options(['Option A', 'Option B', 'Option C'])), ftnt(2)]))
+
+  _row('date', Input(type='date', name='date', hx_trigger='change', hx_post='/controls-htmx/date', **_htmx_tags))
+  _row('time', Input(type='time', name='time', hx_trigger='change', hx_post='/controls-htmx/time', **_htmx_tags))
+  _row('datetime_local', Span(cl='flex-row gap-1ch',
+    _=[Input(type='datetime-local', name='datetime_local', hx_trigger='change', hx_post='/controls-htmx/datetime-local', **_htmx_tags), ftnt(3)]))
+  _row('month', Span(cl='flex-row gap-1ch', _=[Input(type='month', name='month', hx_trigger='change', hx_post='/controls-htmx/month', **_htmx_tags), ftnt(3)]))
+  _row('week', Span(cl='flex-row gap-1ch', _=[Input(type='week', name='week', hx_trigger='change', hx_post='/controls-htmx/week', **_htmx_tags), ftnt(3)]))
+
+
+  _row('color', Input(type='color', name='color', hx_trigger='change', hx_post='/controls-htmx/color', **_htmx_tags))
+
+  _row('range', Input(type='range', name='range', min='0', max='10', hx_trigger='input', hx_post='/controls-htmx/range', **_htmx_tags))
+
+
+  # HTMX reads .value off the triggering element, except when it finds a <form> ancestor,
+  # in which case it uses the JS FormData API (which handles checkboxes, files, etc. correctly).
+  #
+  # File inputs must be wrapped in a <form> because only FormData reads input.files (the actual
+  # binary file handle); without it, HTMX falls back to input.value, which is just a fake path string.
+  _row('file', Span(cl='flex-row gap-1ch',
+    _=[Form(hx_encoding='multipart/form-data', hx_post='/controls-htmx/file', hx_trigger='change', **_htmx_tags,
+      _=Input(type='file', name='file')), ftnt(4)]))
+
+  div.append(Div(cl='flex-col font-small', _=['Notes:',
+  Ol(
+    Li(id='fn1', _='Checkboxes must be wrapped in a <form> so HTMX uses form serialization, which omits the field when'
+      ' unchecked. Without a form ancestor, HTMX reads input.value, which is always "on" regardless of checked state.'),
+    Li(id='fn2', _='Select-multiple inputs must be wrapped in a <form> so HTMX uses form serialization, which captures'
+      ' all selected values. Without a form ancestor, HTMX reads input.value, which returns only the first selected'
+      ' option rather than iterating input.selectedOptions.'),
+    Li(id='fn3', _='Desktop Safari falls back to a plain text field for datetime-local, month, and week input types.'
+      ' Values entered in the text fallback are not validated by the browser.'),
+    Li(id='fn4', _='File inputs must be wrapped in a <form> so HTMX uses the FormData API, which reads the actual file'
+      ' bytes via input.files. Without a form ancestor, HTMX falls back to input.value, which is a fake path string.'),
+  )]))
+
+  return div
+  

--- a/pithy_/pithy/web/dev/routes.py
+++ b/pithy_/pithy/web/dev/routes.py
@@ -1,16 +1,18 @@
 # Dedicated to the public domain under CC0: https://creativecommons.org/publicdomain/zero/1.0/.
 
-from ...html import H1, Main
+import datetime as dt
+
+from ...html import Div, H1, Main, Strong
 from ..endpoint import Endpoint
-from ..request import Request
+from ..request import Request, UploadedFile
 from ..response import HtmlResponse, Response
 from ..static import pithy_web_static_dir_path
-from .controls import controls_form
+from .controls import controls_form, controls_htmx, posted_values
 from .responses import page_html
 
 
 pithy_css_path = pithy_web_static_dir_path() + '/pithy.css'
-
+max_body_bytes = 64 * 1024
 
 class IndexHtml(Endpoint):
   'Returns a simple HTML page.'
@@ -22,12 +24,254 @@ class IndexHtml(Endpoint):
 
 class DevControls(Endpoint):
   'Returns a form for testing controls.'
+  max_body_bytes = 64 * 1024
+
+  text: str | None
+  email: str | None
+  hidden: str | None
+  number: str | None
+  password: str | None
+  tel: str | None
+  url: str | None
+  search: str | None
+  textarea: str | None
+  checkbox: str | None
+  radio: str | None
+  select: str | None
+  date: str | None
+  time: str | None
+  color: str | None
+  range: str | None
+  submit: str | None
+  week: str | None
+  month: str | None
+  datetime_local: str | None
+  select_multiple: list[str] | None
+  file: UploadedFile | None
+
+  def _items(self) -> dict[str, str | list[str]]:
+    return {name: v for name in self._fields if (v := getattr(self, name))}
 
   def handle_request(self, request:Request) -> Response:
     main = Main(
       H1('Dev Controls'),
-      controls_form())
+      posted_values(self._items()),
+      controls_form(self._items()))
     return page_html(title='Dev Controls', main=main)
+
+
+
+class DevControlsHTMX(Endpoint):
+  'Returns a page of testing controls as htmx elements.'
+  max_body_bytes = max_body_bytes
+
+  def handle_request(self, request:Request) -> Response:
+    main = Main(
+			H1('Dev Controls'),
+      posted_values(),
+			controls_htmx())
+    return page_html(title='Dev Controls', main=main)
+
+
+
+class TextHTMX(Endpoint):
+  'Handles updates to the text input on the HTMX DevControls page'
+  max_body_bytes = max_body_bytes
+  text: str | None
+
+  def handle_request(self, request:Request) -> Response:
+    return HtmlResponse(body=Div(Strong('text'), f': {self.text}'))
+
+
+
+class EmailHTMX(Endpoint):
+  'Handles updates to the email input on the HTMX DevControls page'
+  max_body_bytes = max_body_bytes
+  email: str | None
+
+  def handle_request(self, request:Request) -> Response:
+    return HtmlResponse(body=Div(Strong('email'), f': {self.email}'))
+
+
+
+class NumberHTMX(Endpoint):
+  'Handles updates to the number input on the HTMX DevControls page'
+  max_body_bytes = max_body_bytes
+  number: str | None
+
+  def handle_request(self, request:Request) -> Response:
+    return HtmlResponse(body=Div(Strong('number'), f': {self.number}'))
+
+
+
+class PasswordHTMX(Endpoint):
+  'Handles updates to the password input on the HTMX DevControls page'
+  max_body_bytes = max_body_bytes
+  password: str | None
+
+  def handle_request(self, request:Request) -> Response:
+    return HtmlResponse(body=Div(Strong('password'), f': {self.password}'))
+
+
+
+class TelHTMX(Endpoint):
+  'Handles updates to the tel input on the HTMX DevControls page'
+  max_body_bytes = max_body_bytes
+  tel: str | None
+
+  def handle_request(self, request:Request) -> Response:
+    return HtmlResponse(body=Div(Strong('tel'), f': {self.tel}'))
+
+
+
+class UrlHTMX(Endpoint):
+  'Handles updates to the url input on the HTMX DevControls page'
+  max_body_bytes = max_body_bytes
+  url: str | None
+
+  def handle_request(self, request:Request) -> Response:
+    return HtmlResponse(body=Div(Strong('url'), f': {self.url}'))
+
+
+
+class SearchHTMX(Endpoint):
+  'Handles updates to the search input on the HTMX DevControls page'
+  max_body_bytes = max_body_bytes
+  search: str | None
+
+  def handle_request(self, request:Request) -> Response:
+    return HtmlResponse(body=Div(Strong('search'), f': {self.search}'))
+
+
+
+class TextareaHTMX(Endpoint):
+  'Handles updates to the textarea input on the HTMX DevControls page'
+  max_body_bytes = max_body_bytes
+  textarea: str | None
+
+  def handle_request(self, request:Request) -> Response:
+    return HtmlResponse(body=Div(Strong('textarea'), f': {self.textarea}'))
+
+
+
+class CheckboxHTMX(Endpoint):
+  'Handles updates to the checkbox input on the HTMX DevControls page'
+  max_body_bytes = max_body_bytes
+  checkbox: str | None
+
+  def handle_request(self, request:Request) -> Response:
+    return HtmlResponse(body=Div(Strong('checkbox'), f': {self.checkbox}'))
+
+
+
+class RadioHTMX(Endpoint):
+  'Handles updates to the radio input on the HTMX DevControls page'
+  max_body_bytes = max_body_bytes
+  radio: str
+
+  def handle_request(self, request:Request) -> Response:
+    return HtmlResponse(body=Div(Strong('radio'), f': {self.radio}'))
+
+
+
+class SelectHTMX(Endpoint):
+  'Handles updates to the select input on the HTMX DevControls page'
+  max_body_bytes = max_body_bytes
+  select: str
+
+  def handle_request(self, request:Request) -> Response:
+    return HtmlResponse(body=Div(Strong('select'), f': {self.select}'))
+
+
+
+class DateHTMX(Endpoint):
+  'Handles updates to the date input on the HTMX DevControls page'
+  max_body_bytes = max_body_bytes
+  date:dt.date
+
+  def handle_request(self, request:Request) -> Response:
+    return HtmlResponse(body=Div(Strong('date'), f': {self.date}'))
+
+
+
+class TimeHTMX(Endpoint):
+  'Handles updates to the time input on the HTMX DevControls page'
+  max_body_bytes = max_body_bytes
+  time: dt.time
+
+  def handle_request(self, request:Request) -> Response:
+    return HtmlResponse(body=Div(Strong('time'), f': {self.time}'))
+
+
+
+class DatetimeLocalHTMX(Endpoint):
+  'Handles updates to the datetime-local input on the HTMX DevControls page'
+  max_body_bytes = max_body_bytes
+  datetime_local: dt.datetime
+
+  def handle_request(self, request:Request) -> Response:
+    return HtmlResponse(body=Div(Strong('datetime-local'), f': {self.datetime_local}'))
+
+
+
+class MonthHTMX(Endpoint):
+  'Handles updates to the month input on the HTMX DevControls page'
+  max_body_bytes = max_body_bytes
+  month: str
+
+  def handle_request(self, request:Request) -> Response:
+    return HtmlResponse(body=Div(Strong('month'), f': {self.month}'))
+
+
+
+class WeekHTMX(Endpoint):
+  'Handles updates to the week input on the HTMX DevControls page'
+  max_body_bytes = max_body_bytes
+  week: str
+
+  def handle_request(self, request:Request) -> Response:
+    return HtmlResponse(body=Div(Strong('week'), f': {self.week}'))
+
+
+
+class ColorHTMX(Endpoint):
+  'Handles updates to the color input on the HTMX DevControls page'
+  max_body_bytes = max_body_bytes
+  color: str
+
+  def handle_request(self, request:Request) -> Response:
+    return HtmlResponse(body=Div(Strong('color'), f': {self.color}'))
+
+
+
+class RangeHTMX(Endpoint):
+  'Handles updates to the range input on the HTMX DevControls page'
+  max_body_bytes = max_body_bytes
+  range: int
+
+  def handle_request(self, request:Request) -> Response:
+    return HtmlResponse(body=Div(Strong('range'), f': {self.range}'))
+
+
+
+class SelectMultipleHTMX(Endpoint):
+  'Handles updates to the select-multiple input on the HTMX DevControls page.'
+  max_body_bytes = max_body_bytes
+  select_multiple: list[str]
+
+  def handle_request(self, request:Request) -> Response:
+    return HtmlResponse(body=Div(Strong('select-multiple'), f': {", ".join(self.select_multiple)}'))
+
+
+
+class FileHTMX(Endpoint):
+  'Handles file uploads on the HTMX DevControls page.'
+  max_body_bytes = max_body_bytes
+  file: UploadedFile
+
+  def handle_request(self, request:Request) -> Response:
+    return HtmlResponse(body=Div(Strong('file'), f': {self.file.filename} ({len(self.file.data)} bytes)'))
+
 
 
 class PithyCss(Endpoint):
@@ -43,5 +287,26 @@ class PithyCss(Endpoint):
 routes:dict[str,type[Endpoint]] = {
   '/': IndexHtml,
   '/controls': DevControls,
+  '/controls-htmx': DevControlsHTMX,
+  '/controls-htmx/text': TextHTMX,
+  '/controls-htmx/email': EmailHTMX,
+  '/controls-htmx/number': NumberHTMX,
+  '/controls-htmx/password': PasswordHTMX,
+  '/controls-htmx/tel': TelHTMX,
+  '/controls-htmx/url': UrlHTMX,
+  '/controls-htmx/search': SearchHTMX,
+  '/controls-htmx/textarea': TextareaHTMX,
+  '/controls-htmx/checkbox': CheckboxHTMX,
+  '/controls-htmx/radio': RadioHTMX,
+  '/controls-htmx/select': SelectHTMX,
+  '/controls-htmx/date': DateHTMX,
+  '/controls-htmx/time': TimeHTMX,
+  '/controls-htmx/datetime-local': DatetimeLocalHTMX,
+  '/controls-htmx/month': MonthHTMX,
+  '/controls-htmx/week': WeekHTMX,
+  '/controls-htmx/color': ColorHTMX,
+  '/controls-htmx/range': RangeHTMX,
+  '/controls-htmx/select-multiple': SelectMultipleHTMX,
+  '/controls-htmx/file': FileHTMX,
   '/pithy.css': PithyCss,
 }

--- a/pithy_/pithy/web/dev/routes.py
+++ b/pithy_/pithy/web/dev/routes.py
@@ -50,7 +50,7 @@ class DevControls(Endpoint):
   file: UploadedFile | None
 
   def _items(self) -> dict[str, str | list[str]]:
-    return {name: v for name in self._fields if (v := getattr(self, name))}
+    return {name: v for name in self._field_transtructors if (v := getattr(self, name))}
 
   def handle_request(self, request:Request) -> Response:
     main = Main(

--- a/pithy_/pithy/web/echoapp.py
+++ b/pithy_/pithy/web/echoapp.py
@@ -17,7 +17,7 @@ class EchoApp(WebApp):
       case 'application/x-www-form-urlencoded':
         params = request.parse_urlencoded(max_bytes=16_384)
         if params:
-          req_body_str = '\n'.join(f'{k}: {v}' for k, vs in params.items() for v in vs)
+          req_body_str = '\n'.join(f'{k}: {vs}' for k, vs in params.items())
       case 'application/json':
         data = request.parse_json(max_bytes=16_384)
         # TODO: use a nicer json renderer implemented in pithy.json.render.
@@ -31,11 +31,7 @@ class EchoApp(WebApp):
         if parts:
           part_lines = []
           for k, vs in parts.items():
-            for v in vs:
-              if isinstance(v, str):
-                part_lines.append(f'{k}: {v}')
-              else:
-                part_lines.append(f'{k}: {v.filename} ({v.content_type}, {len(v.data)} bytes)')
+            part_lines.append(f'{k}: {vs}')
           req_body_str = '\n'.join(part_lines)
       case _:
         raw = request.read_body(max_bytes=16_384)

--- a/pithy_/pithy/web/endpoint.py
+++ b/pithy_/pithy/web/endpoint.py
@@ -1,15 +1,12 @@
 # Dedicated to the public domain under CC0: https://creativecommons.org/publicdomain/zero/1.0/.
 
-import types
 from collections.abc import Mapping
-from dataclasses import dataclass
 from datetime import date, datetime, time
 from http import HTTPStatus
-from typing import Any, ClassVar, get_args, get_origin, get_type_hints
+from inspect import get_annotations
+from typing import Any, ClassVar, get_origin, get_type_hints
 
-from pithy.type_utils import is_a
-
-from ..transtruct import bool_str_vals
+from ..transtruct import PrefigureFn, TranstructFn, Transtructor, TranstructorError
 from .errors import BadRequestError
 from .handler import RequestHandler
 from .request import Request, UploadedFile
@@ -27,9 +24,9 @@ class Endpoint(RequestHandler):
   Use `list[T]` to collect multiple values for one key (e.g. multi-select).
   Use `list[T]|None` for an optional multi-value field (None if no values are submitted).
 
-  To add custom type converters, define `_converters` as a class variable mapping types to callables:
+  To add custom type conversions, define `_prefigures` as a class variable mapping types to prefigure functions:
     class MyEndpoint(Endpoint):
-      _converters = {MyType: MyType.from_string}
+      _prefigures = {MyType: lambda cls, val, ctx: MyType.from_string(val)}
       my_field: MyType
 
   All Endpoint classes take the following constructor parameters:
@@ -48,8 +45,8 @@ class Endpoint(RequestHandler):
 
   max_body_bytes:ClassVar[int] = 0 # Must be overridden by subclasses that expect body parameters.
 
-  _fields:ClassVar[dict[str,_FieldInfo]]
-  _converters:ClassVar[dict[type,Any]]
+  _field_transtructors:ClassVar[dict[str,TranstructFn[Any]]]
+  _prefigures:ClassVar[dict[type,PrefigureFn]]
 
   path_params:Mapping[str,object]
 
@@ -59,31 +56,19 @@ class Endpoint(RequestHandler):
   def __init_subclass__(cls, **kwargs:Any) -> None:
     super().__init_subclass__(**kwargs)
 
-    # Build converters: start with defaults, layer in any _converters defined on classes in the MRO.
-    converters:dict[type,Any] = dict(_default_converters)
+    # Build a per-class transtructor seeded with module-level defaults, then layer in _prefigures from the MRO.
+    ttor = Transtructor()
+    ttor.prefigures.update(endpoint_transtructor.prefigures)
     for base in reversed(cls.__mro__):
       if base is Endpoint: continue
-      base_conv = base.__dict__.get('_converters')
-      if base_conv:
-        converters.update(base_conv)
-    cls._converters = converters
+      for type_, fn in base.__dict__.get('_prefigures', {}).items():
+        ttor.prefigures[type_] = fn
 
-    # Introspect type hints to build field metadata.
-    hints = get_type_hints(cls)
-    fields:dict[str,_FieldInfo] = {}
-    for name, hint in hints.items():
-      if name.startswith('_'): continue
-      base_type, is_optional = _unwrap_optional(hint)
-      inner = base_type if base_type is not None else hint
-      is_list = get_origin(inner) is list
-      if is_list:
-        base_type = get_args(inner)[0]
-      if base_type is None: continue
-      converter = converters.get(base_type)
-      if converter is None:
-        raise TypeError(f'{cls.__qualname__}.{name}: no converter registered for type {base_type!r}.')
-      fields[name] = _FieldInfo(name=name, type=base_type, is_optional=is_optional, is_list=is_list, converter=converter)
-    cls._fields = fields
+    fields:dict[str,TranstructFn[Any]] = {}
+    for name, hint in get_type_hints(cls).items():
+      if name.startswith('_') or name in _endpoint_annotations or get_origin(hint) is ClassVar: continue
+      fields[name] = ttor.transtructor_for(hint)
+    cls._field_transtructors = fields
 
 
   def __init__(self, request:Request, path_params:Mapping[str,object]) -> None:
@@ -118,12 +103,12 @@ class Endpoint(RequestHandler):
       for name, raw in request.body_params(self.max_body_bytes).items():
         self._fill_param(name=name, raw=raw, source='body')
 
-    # Check for missing required fields and set optional fields to None.
-    for name, field in self._fields.items():
+    # Check for missing fields; let the transtructor determine if None is acceptable.
+    for name, transtructor in self._field_transtructors.items():
       if hasattr(self, name): continue
-      if not field.is_optional:
+      try: setattr(self, name, transtructor(None, None))
+      except (ValueError, TypeError, TranstructorError):
         raise BadRequestError(f'Missing required parameter: {name!r}.')
-      setattr(self, name, None)
 
 
   def handle_request(self, request:Request) -> Response:
@@ -133,76 +118,49 @@ class Endpoint(RequestHandler):
   def _fill_param(self, name:str, raw:object, source:str) -> None:
     if prev_source := self._fill_param_sources.get(name):
       raise BadRequestError(f'Duplicate parameter {name!r} in {prev_source} and {source}.')
-    field = self._fields.get(name)
-    if field is None:
+    transtructor = self._field_transtructors.get(name)
+    if transtructor is None:
       raise BadRequestError(f'Unknown parameter {name!r} in {source}.')
     self._fill_param_sources[name] = source
 
-    # list fields
-    if field.is_list:
-      if not isinstance(raw, list): raw = [raw]
-      if is_a(raw, list[field.type]):  # type: ignore[name-defined]
-        setattr(self, field.name, raw)
-        return
-      try:
-        setattr(self, field.name, [field.converter(r) for r in raw])
-      except (ValueError, TypeError) as e:
-        raise BadRequestError(f'Invalid value for parameter {name!r}: {raw!r}.') from e
-      return
-
-    # scalar fields
-    if isinstance(raw, field.type):
-      setattr(self, field.name, raw)
-      return
-    # Reject nested JSON objects; str() would silently stringify them rather than raising.
-    if isinstance(raw, dict):
-      raise BadRequestError(f'Invalid value for parameter {name!r}: nested objects are not supported.')
     try:
-      setattr(self, field.name, field.converter(raw))
-    except (ValueError, TypeError) as e:
+      setattr(self, name, transtructor(raw, None))
+    except (ValueError, TypeError, TranstructorError) as e:
       raise BadRequestError(f'Invalid value for parameter {name!r}: {raw!r}.') from e
 
 
-@dataclass(slots=True, frozen=True)
-class _FieldInfo:
-  'Metadata for a single declared field on an Endpoint subclass.'
-  name: str
-  type: type
-  is_optional: bool
-  is_list: bool
-  converter: Any
+# Declare module-level transtructor that can be imported and extended by endpoint consumers if
+# there's desired behavior for all endpoints.
+endpoint_transtructor = Transtructor()
+
+# Used so we can reliably ignore fields set on endpoint class.
+_endpoint_annotations = frozenset(get_annotations(Endpoint).keys())
+
+@endpoint_transtructor.prefigure(list)
+def _prefigure_list(cls:type, val:Any, ctx:Any) -> list:
+  if isinstance(val, str): return [val]
+  return val
+
+@endpoint_transtructor.prefigure(date)
+def _prefigure_date(cls:type, val:Any, ctx:Any) -> date:
+  if isinstance(val, date) and not isinstance(val, datetime): return val
+  return date.fromisoformat(val)
 
 
-def _unwrap_optional(hint:Any) -> tuple[type|None,bool]:
-  'Extract the base type and whether the hint is optional (T | None). Returns (None, False) for unsupported hints.'
-  origin = get_origin(hint)
-  if origin is types.UnionType:
-    args = get_args(hint)
-    non_none = [a for a in args if a is not type(None)]
-    if type(None) in args and len(non_none) == 1:
-      return (non_none[0], True)
-    return (None, False)
-  if isinstance(hint, type):
-    return (hint, False)
-  return (None, False)
+@endpoint_transtructor.prefigure(time)
+def _prefigure_time(cls:type, val:Any, ctx:Any) -> time:
+  if isinstance(val, time): return val
+  return time.fromisoformat(val)
 
 
-def _parse_bool(s:str) -> bool:
-  try: return bool_str_vals[s]
-  except KeyError: raise ValueError(f'Invalid bool value: {s!r}.')
+@endpoint_transtructor.prefigure(datetime)
+def _prefigure_datetime(cls:type, val:Any, ctx:Any) -> datetime:
+  if isinstance(val, datetime): return val
+  return datetime.fromisoformat(val)
 
-
-def _require_uploaded_file(x:Any) -> UploadedFile:
-  raise ValueError(f'Expected a file upload, got {type(x).__name__!r}.')
-
-
-_default_converters:dict[type,Any] = {
-  str: str,
-  int: int,
-  float: float,
-  bool: _parse_bool,
-  date: date.fromisoformat,
-  time: time.fromisoformat,
-  datetime: datetime.fromisoformat,
-  UploadedFile: _require_uploaded_file,
-}
+# This is here so that JSON dicts with the exact keys as UploadedFile dataclass
+# don't silently get converted.
+@endpoint_transtructor.prefigure(UploadedFile)
+def _prefigure_uploaded_file(cls:type, val:Any, ctx:Any) -> UploadedFile:
+  if isinstance(val, UploadedFile): return val
+  raise ValueError(f'Expected a file upload, got {type(val).__name__!r}.')

--- a/pithy_/pithy/web/endpoint.py
+++ b/pithy_/pithy/web/endpoint.py
@@ -154,6 +154,9 @@ class Endpoint(RequestHandler):
     if isinstance(raw, field.type):
       setattr(self, field.name, raw)
       return
+    # Reject nested JSON objects; str() would silently stringify them rather than raising.
+    if isinstance(raw, dict):
+      raise BadRequestError(f'Invalid value for parameter {name!r}: nested objects are not supported.')
     try:
       setattr(self, field.name, field.converter(raw))
     except (ValueError, TypeError) as e:

--- a/pithy_/pithy/web/endpoint.py
+++ b/pithy_/pithy/web/endpoint.py
@@ -2,14 +2,17 @@
 
 import types
 from collections.abc import Mapping
-from datetime import date, datetime
+from dataclasses import dataclass
+from datetime import date, datetime, time
 from http import HTTPStatus
 from typing import Any, ClassVar, get_args, get_origin, get_type_hints
+
+from pithy.type_utils import is_a
 
 from ..transtruct import bool_str_vals
 from .errors import BadRequestError
 from .handler import RequestHandler
-from .request import Request
+from .request import Request, UploadedFile
 from .response import Response
 
 
@@ -21,6 +24,8 @@ class Endpoint(RequestHandler):
   The field types determine how raw values are converted.
 
   Use `T|None` to mark a field as optional (None if the parameter is absent).
+  Use `list[T]` to collect multiple values for one key (e.g. multi-select).
+  Use `list[T]|None` for an optional multi-value field (None if no values are submitted).
 
   To add custom type converters, define `_converters` as a class variable mapping types to callables:
     class MyEndpoint(Endpoint):
@@ -69,11 +74,15 @@ class Endpoint(RequestHandler):
     for name, hint in hints.items():
       if name.startswith('_'): continue
       base_type, is_optional = _unwrap_optional(hint)
+      inner = base_type if base_type is not None else hint
+      is_list = get_origin(inner) is list
+      if is_list:
+        base_type = get_args(inner)[0]
       if base_type is None: continue
       converter = converters.get(base_type)
       if converter is None:
         raise TypeError(f'{cls.__qualname__}.{name}: no converter registered for type {base_type!r}.')
-      fields[name] = _FieldInfo(name=name, type_=base_type, is_optional=is_optional, converter=converter)
+      fields[name] = _FieldInfo(name=name, type=base_type, is_optional=is_optional, is_list=is_list, converter=converter)
     cls._fields = fields
 
 
@@ -128,6 +137,20 @@ class Endpoint(RequestHandler):
     if field is None:
       raise BadRequestError(f'Unknown parameter {name!r} in {source}.')
     self._fill_param_sources[name] = source
+
+    # list fields
+    if field.is_list:
+      if not isinstance(raw, list): raw = [raw]
+      if is_a(raw, list[field.type]):  # type: ignore[name-defined]
+        setattr(self, field.name, raw)
+        return
+      try:
+        setattr(self, field.name, [field.converter(r) for r in raw])
+      except (ValueError, TypeError) as e:
+        raise BadRequestError(f'Invalid value for parameter {name!r}: {raw!r}.') from e
+      return
+
+    # scalar fields
     if isinstance(raw, field.type):
       setattr(self, field.name, raw)
       return
@@ -137,15 +160,14 @@ class Endpoint(RequestHandler):
       raise BadRequestError(f'Invalid value for parameter {name!r}: {raw!r}.') from e
 
 
+@dataclass(slots=True, frozen=True)
 class _FieldInfo:
   'Metadata for a single declared field on an Endpoint subclass.'
-  __slots__ = ('name', 'type', 'is_optional', 'converter')
-
-  def __init__(self, name:str, type_:type, is_optional:bool, converter:Any) -> None:
-    self.name = name
-    self.type = type_
-    self.is_optional = is_optional
-    self.converter = converter
+  name: str
+  type: type
+  is_optional: bool
+  is_list: bool
+  converter: Any
 
 
 def _unwrap_optional(hint:Any) -> tuple[type|None,bool]:
@@ -167,11 +189,17 @@ def _parse_bool(s:str) -> bool:
   except KeyError: raise ValueError(f'Invalid bool value: {s!r}.')
 
 
+def _require_uploaded_file(x:Any) -> UploadedFile:
+  raise ValueError(f'Expected a file upload, got {type(x).__name__!r}.')
+
+
 _default_converters:dict[type,Any] = {
   str: str,
   int: int,
   float: float,
   bool: _parse_bool,
   date: date.fromisoformat,
+  time: time.fromisoformat,
   datetime: datetime.fromisoformat,
+  UploadedFile: _require_uploaded_file,
 }

--- a/pithy_/pithy/web/endpoint.ut.py
+++ b/pithy_/pithy/web/endpoint.ut.py
@@ -204,6 +204,13 @@ class BodyEndpoint(Endpoint):
   def handle_request(self, request:Request) -> Response:
     return Response(body=f'{self.name},{self.tag}')
 
+class ListEndpoint(Endpoint):
+  max_body_bytes = 1024
+  tags: list[str]
+  counts: list[int]
+  def handle_request(self, request:Request) -> Response:
+    return Response(body=f'{self.tags},{self.counts}')
+
 
 @utest_run
 def _() -> None:
@@ -241,14 +248,37 @@ def _() -> None:
   utest_exc(ResponseError, ep.prepare, req)
 
 
+# JSON body with non-string value types.
+
+@utest_run
+def _() -> None:
+  'Endpoint: prepare fills int field from JSON body with integer value.'
+  req = _make_request(media_type='application/json', body=b'{"id":3}')
+  ep = IntEndpoint(req, path_params={})
+  ep.prepare(req)
+  utest_val(3, ep.id)
+
+
+@utest_run
+def _() -> None:
+  'Endpoint: prepare fills list fields from JSON body with array values.'
+  req = _make_request(media_type='application/json', body=b'{"tags":["a","b"],"counts":[1,2]}')
+  ep = ListEndpoint(req, path_params={})
+  ep.prepare(req)
+  utest_val(['a', 'b'], ep.tags)
+  utest_val([1, 2], ep.counts)
+
+
+@utest_run
+def _() -> None:
+  'Endpoint: prepare raises on nested dict value in JSON body.'
+  req = _make_request(media_type='application/json', body=b'{"name":{"first":"alice"}}')
+  ep = BodyEndpoint(req, path_params={})
+  utest_exc(ResponseError, ep.prepare, req)
+
+
 # List fields.
 
-class ListEndpoint(Endpoint):
-  max_body_bytes = 1024
-  tags: list[str]
-  counts: list[int]
-  def handle_request(self, request:Request) -> Response:
-    return Response(body=f'{self.tags},{self.counts}')
 
 
 class OptionalListEndpoint(Endpoint):

--- a/pithy_/pithy/web/endpoint.ut.py
+++ b/pithy_/pithy/web/endpoint.ut.py
@@ -1,5 +1,6 @@
 # Dedicated to the public domain under CC0: https://creativecommons.org/publicdomain/zero/1.0/.
 
+from dataclasses import dataclass
 from datetime import date, datetime, time
 from enum import Enum
 from http import HTTPStatus
@@ -77,7 +78,7 @@ def endpoint_fields(cls:type[Endpoint], **kwargs:str) -> dict[str,Any]:
   request = _make_request()
   ep = cls(request=request, path_params=kwargs)
   ep.prepare(request)
-  return {k: getattr(ep, k) for k in ep._fields}
+  return {k: getattr(ep, k) for k in ep._field_transtructors}
 
 
 # Field parsing from path params (string conversion).
@@ -105,7 +106,7 @@ def _() -> None:
     utest_val(False, ep.flag, desc=f'bool from {s!r}')
 
 
-# Custom converters.
+# Custom prefigures.
 
 class Color(Enum):
   red = 'red'
@@ -113,32 +114,32 @@ class Color(Enum):
   blue = 'blue'
 
 
-class CustomConverterEndpoint(Endpoint):
-  _converters = {Color: lambda s: Color(s)}
+class CustomPrefigureEndpoint(Endpoint):
+  _prefigures = {Color: lambda cls, val, ctx: Color(val)}
   color:Color
 
   def handle_request(self, request:Request) -> Response:
     return Response(body=f'{self.color.value}')
 
 
-utest(dict(color=Color.red), endpoint_fields, CustomConverterEndpoint, color='red')
-utest_exc(ResponseError, CustomConverterEndpoint, _make_request(), dict(color='purple'))
+utest(dict(color=Color.red), endpoint_fields, CustomPrefigureEndpoint, color='red')
+utest_exc(ResponseError, CustomPrefigureEndpoint, _make_request(), dict(color='purple'))
 
 
-# Custom converter inheritance.
+# Custom prefigure inheritance.
 
-class BaseConverterEndpoint(Endpoint):
-  _converters = {Color: lambda s: Color(s)}
+class BasePrefigureEndpoint(Endpoint):
+  _prefigures = {Color: lambda cls, val, ctx: Color(val)}
 
 
-class InheritedConverterEndpoint(BaseConverterEndpoint):
+class InheritedPrefigureEndpoint(BasePrefigureEndpoint):
   color:Color
   name:str
   def handle_request(self, request:Request) -> Response:
     return Response(body=f'{self.color.value},{self.name}')
 
 
-utest(dict(color=Color.green, name='test'), endpoint_fields, InheritedConverterEndpoint, color='green', name='test')
+utest(dict(color=Color.green, name='test'), endpoint_fields, InheritedPrefigureEndpoint, color='green', name='test')
 
 
 # No-field endpoint.
@@ -261,6 +262,14 @@ def _() -> None:
 
 @utest_run
 def _() -> None:
+  'Endpoint: str field rejects JSON integer value.'
+  req = _make_request(media_type='application/json', body=b'{"name":123}')
+  ep = BodyEndpoint(req, path_params={})
+  utest_exc(ResponseError, ep.prepare, req)
+
+
+@utest_run
+def _() -> None:
   'Endpoint: prepare fills list fields from JSON body with array values.'
   req = _make_request(media_type='application/json', body=b'{"tags":["a","b"],"counts":[1,2]}')
   ep = ListEndpoint(req, path_params={})
@@ -269,12 +278,44 @@ def _() -> None:
   utest_val([1, 2], ep.counts)
 
 
+# Nested dataclass fields.
+
+@dataclass
+class Point:
+  x:int
+  y:int
+
+
+class NestedEndpoint(Endpoint):
+  max_body_bytes = 1024
+  point:Point
+  def handle_request(self, request:Request) -> Response:
+    return Response(body=f'{self.point}')
+
+
+class NestedListEndpoint(Endpoint):
+  max_body_bytes = 1024
+  points:list[Point]
+  def handle_request(self, request:Request) -> Response:
+    return Response(body=f'{self.points}')
+
+
 @utest_run
 def _() -> None:
-  'Endpoint: prepare raises on nested dict value in JSON body.'
-  req = _make_request(media_type='application/json', body=b'{"name":{"first":"alice"}}')
-  ep = BodyEndpoint(req, path_params={})
-  utest_exc(ResponseError, ep.prepare, req)
+  'Endpoint: nested dataclass field filled from JSON body.'
+  req = _make_request(media_type='application/json', body=b'{"point":{"x":1,"y":2}}')
+  ep = NestedEndpoint(req, path_params={})
+  ep.prepare(req)
+  utest_val(Point(1, 2), ep.point)
+
+
+@utest_run
+def _() -> None:
+  'Endpoint: list[dataclass] field filled from JSON body.'
+  req = _make_request(media_type='application/json', body=b'{"points":[{"x":1,"y":2},{"x":3,"y":4}]}')
+  ep = NestedListEndpoint(req, path_params={})
+  ep.prepare(req)
+  utest_val([Point(1, 2), Point(3, 4)], ep.points)
 
 
 # List fields.
@@ -306,7 +347,7 @@ def endpoint_body_fields(cls:type[Endpoint], body:str) -> dict[str,Any]:
   req = _urlencoded_request(body)
   ep = cls(req, path_params={})
   ep.prepare(req)
-  return {k: getattr(ep, k) for k in ep._fields}
+  return {k: getattr(ep, k) for k in ep._field_transtructors}
 
 
 @utest_run
@@ -354,7 +395,6 @@ class UploadedFileEndpoint(Endpoint):
   file:UploadedFile
   def handle_request(self, request:Request) -> Response:
     return Response(body=f'{self.file.filename}')
-
 
 @utest_run
 def _() -> None:

--- a/pithy_/pithy/web/endpoint.ut.py
+++ b/pithy_/pithy/web/endpoint.ut.py
@@ -1,6 +1,6 @@
 # Dedicated to the public domain under CC0: https://creativecommons.org/publicdomain/zero/1.0/.
 
-from datetime import date, datetime
+from datetime import date, datetime, time
 from enum import Enum
 from http import HTTPStatus
 from typing import Any
@@ -8,7 +8,7 @@ from urllib.parse import urlencode
 
 from pithy.web.endpoint import Endpoint
 from pithy.web.errors import ResponseError
-from pithy.web.request import Request
+from pithy.web.request import Request, UploadedFile
 from pithy.web.requestconn import BytesConn
 from pithy.web.response import Response
 from utest import utest, utest_exc, utest_run, utest_val
@@ -60,6 +60,12 @@ class DatetimeEndpoint(Endpoint):
     return Response(body=f'{self.dt}')
 
 
+class TimeEndpoint(Endpoint):
+  t:time
+  def handle_request(self, request:Request) -> Response:
+    return Response(body=f'{self.t}')
+
+
 class BoolEndpoint(Endpoint):
   flag:bool
   def handle_request(self, request:Request) -> Response:
@@ -81,6 +87,7 @@ utest(dict(name='alice', tag='admin'), endpoint_fields, OptionalEndpoint, name='
 utest(dict(name='alice', tag=None), endpoint_fields, OptionalEndpoint, name='alice')
 utest(dict(d=date(2026, 3, 14)), endpoint_fields, DateEndpoint, d='2026-03-14')
 utest(dict(dt=datetime(2026, 3, 14, 12, 0)), endpoint_fields, DatetimeEndpoint, dt='2026-03-14T12:00:00')
+utest(dict(t=time(12, 30)), endpoint_fields, TimeEndpoint, t='12:30:00')
 
 # Error cases.
 utest_exc(ResponseError, endpoint_fields, IntEndpoint) # Missing required param.
@@ -232,3 +239,108 @@ def _() -> None:
   req = _make_request()
   ep = BodyEndpoint(req, path_params={})
   utest_exc(ResponseError, ep.prepare, req)
+
+
+# List fields.
+
+class ListEndpoint(Endpoint):
+  max_body_bytes = 1024
+  tags: list[str]
+  counts: list[int]
+  def handle_request(self, request:Request) -> Response:
+    return Response(body=f'{self.tags},{self.counts}')
+
+
+class OptionalListEndpoint(Endpoint):
+  max_body_bytes = 1024
+  tags: list[str]|None
+  def handle_request(self, request:Request) -> Response:
+    return Response(body=f'{self.tags}')
+
+
+def _urlencoded_request(body:str) -> Request:
+  return _make_request(media_type='application/x-www-form-urlencoded', body=body.encode())
+
+
+def _multipart_request(boundary:str, *parts:bytes) -> Request:
+  b = boundary.encode()
+  body = b''
+  for part in parts:
+    body += b'--' + b + b'\r\n' + part + b'\r\n'
+  body += b'--' + b + b'--\r\n'
+  return _make_request(media_type=f'multipart/form-data; boundary={boundary}', body=body)
+
+
+def endpoint_body_fields(cls:type[Endpoint], body:str) -> dict[str,Any]:
+  'Construct an endpoint with a urlencoded body, prepare it, and return the populated field values.'
+  req = _urlencoded_request(body)
+  ep = cls(req, path_params={})
+  ep.prepare(req)
+  return {k: getattr(ep, k) for k in ep._fields}
+
+
+@utest_run
+def _() -> None:
+  'Endpoint: list[str] field filled from urlencoded body with multiple values.'
+  result = endpoint_body_fields(ListEndpoint, 'tags=a&tags=b&tags=c&counts=1&counts=2')
+  utest_val(['a', 'b', 'c'], result['tags'])
+  utest_val([1, 2], result['counts'])
+
+
+@utest_run
+def _() -> None:
+  'Endpoint: list[str]|None field with values present.'
+  result = endpoint_body_fields(OptionalListEndpoint, 'tags=x&tags=y')
+  utest_val(['x', 'y'], result['tags'])
+
+
+@utest_run
+def _() -> None:
+  'Endpoint: list[str]|None field absent from body is None.'
+  result = endpoint_body_fields(OptionalListEndpoint, '')
+  utest_val(None, result['tags'])
+
+
+@utest_run
+def _() -> None:
+  'Endpoint: list[str] required but not submitted raises BadRequestError.'
+  req = _urlencoded_request('')
+  ep = ListEndpoint(req, path_params={})
+  utest_exc(ResponseError, ep.prepare, req)
+
+
+@utest_run
+def _() -> None:
+  'Endpoint: list field same name from query and body raises BadRequestError.'
+  req = _make_request(query=dict(tags='a'), media_type='application/x-www-form-urlencoded', body=b'tags=b&counts=1')
+  ep = ListEndpoint(req, path_params={})
+  utest_exc(ResponseError, ep.prepare, req)
+
+
+# UploadedFile fields.
+
+class UploadedFileEndpoint(Endpoint):
+  max_body_bytes = 4096
+  file:UploadedFile
+  def handle_request(self, request:Request) -> Response:
+    return Response(body=f'{self.file.filename}')
+
+
+@utest_run
+def _() -> None:
+  'Endpoint: UploadedFile field filled from multipart body.'
+  part = b'Content-Disposition: form-data; name="file"; filename="hello.txt"\r\nContent-Type: application/octet-stream\r\n\r\nhello'
+  req = _multipart_request('boundary123', part)
+  ep = UploadedFileEndpoint(req, path_params={})
+  ep.prepare(req)
+  utest_val('hello.txt', ep.file.filename)
+  utest_val(b'hello', ep.file.data)
+
+
+@utest_run
+def _() -> None:
+  'Endpoint: UploadedFile field raises BadRequestError when given a string value.'
+  req = _urlencoded_request('file=not-a-file')
+  ep = UploadedFileEndpoint(req, path_params={})
+  utest_exc(ResponseError, ep.prepare, req)
+

--- a/pithy_/pithy/web/request.py
+++ b/pithy_/pithy/web/request.py
@@ -4,7 +4,7 @@ import io
 from dataclasses import dataclass
 from functools import cached_property
 from http import HTTPStatus
-from typing import cast
+from typing import Any, cast
 from urllib.parse import parse_qsl
 
 from python_multipart import parse_form
@@ -12,7 +12,6 @@ from python_multipart.multipart import Field, File
 
 from ..http import http_methods
 from ..json import Json, parse_json
-from ..type_utils import is_a
 from .errors import BadRequestError, decode_or_bad_request
 from .requestconn import AddrPair, RequestConn
 from .response import ResponseError
@@ -139,16 +138,15 @@ class Request:
     return q
 
 
-  def body_params(self, max_bytes:int) -> dict[str,MultipartVal|list[MultipartVal]]:
+  def body_params(self, max_bytes:int) -> dict[str,Any]:
     'Parse and cache the request body based on media type and return a dict mapping parameter names to values.'
     match self.media_type:
       case 'application/x-www-form-urlencoded':
         return cast(dict[str,MultipartVal|list[MultipartVal]], self.parse_urlencoded(max_bytes=max_bytes))
       case 'application/json':
         data = self.parse_json(max_bytes=max_bytes)
-        # TODO: currently only string values are supported in JSON bodies; revisit if we want to support int/bool/nested types.
-        if not is_a(data, dict[str,str]): raise BadRequestError('Expected JSON object with string values in request body.')
-        return cast(dict[str,MultipartVal|list[MultipartVal]], data)
+        if isinstance(data, dict): return data
+        raise BadRequestError('Expected JSON object in request body.')
       case 'multipart/form-data':
         return self.parse_multipart(max_bytes=max_bytes)
       case _:

--- a/pithy_/pithy/web/request.py
+++ b/pithy_/pithy/web/request.py
@@ -4,14 +4,15 @@ import io
 from dataclasses import dataclass
 from functools import cached_property
 from http import HTTPStatus
-from typing import Any
-from urllib.parse import parse_qs, parse_qsl
+from typing import cast
+from urllib.parse import parse_qsl
 
 from python_multipart import parse_form
 from python_multipart.multipart import Field, File
 
 from ..http import http_methods
 from ..json import Json, parse_json
+from ..type_utils import is_a
 from .errors import BadRequestError, decode_or_bad_request
 from .requestconn import AddrPair, RequestConn
 from .response import ResponseError
@@ -31,6 +32,17 @@ class UploadedFile:
   filename:str
   data:bytes
   content_type:str
+
+  def __str__(self) -> str: return f'{self.filename} ({self.content_type}, {len(self.data)} bytes)'
+
+type MultipartVal = str | UploadedFile
+
+def _add_to_param_dict[V](d:dict[str,V|list[V]], k:str, v:V) -> None:
+  try: existing = d[k]
+  except KeyError: d[k] = v # Add first value as scalar
+  else: # Existing value.
+    if isinstance(existing, list): existing.append(v)
+    else: d[k] = [existing, v]
 
 
 @dataclass
@@ -127,48 +139,43 @@ class Request:
     return q
 
 
-  def body_params(self, max_bytes:int) -> dict[str,Any]:
-    'Parse and cache the request body based on media type and return a flat dict of parameters.'
+  def body_params(self, max_bytes:int) -> dict[str,MultipartVal|list[MultipartVal]]:
+    'Parse and cache the request body based on media type and return a dict mapping parameter names to values.'
     match self.media_type:
       case 'application/x-www-form-urlencoded':
-        multi = self.parse_urlencoded(max_bytes=max_bytes)
-        return {k: vs[0] for k, vs in multi.items() if vs}
+        return cast(dict[str,MultipartVal|list[MultipartVal]], self.parse_urlencoded(max_bytes=max_bytes))
       case 'application/json':
         data = self.parse_json(max_bytes=max_bytes)
-        if isinstance(data, dict): return data
-        raise BadRequestError('Expected JSON object in request body.')
+        # TODO: currently only string values are supported in JSON bodies; revisit if we want to support int/bool/nested types.
+        if not is_a(data, dict[str,str]): raise BadRequestError('Expected JSON object with string values in request body.')
+        return cast(dict[str,MultipartVal|list[MultipartVal]], data)
       case 'multipart/form-data':
-        parts = self.parse_multipart(max_bytes=max_bytes)
-        result:dict[str,Any] = {}
-        for k, vs in parts.items():
-          for v in vs:
-            if isinstance(v, str):
-              result[k] = v
-              break
-        return result
+        return self.parse_multipart(max_bytes=max_bytes)
       case _:
         raise ResponseError(status=HTTPStatus.UNSUPPORTED_MEDIA_TYPE, reason=f'Unsupported media type: {self.media_type!r}.')
 
 
-  def parse_multipart(self, max_bytes:int) -> dict[str,list[str|UploadedFile]]:
+  def parse_multipart(self, max_bytes:int) -> dict[str,MultipartVal|list[MultipartVal]]:
     '''Parse a multipart/form-data body. Text fields become str values; file parts become UploadedFile values.'''
     if self.media_type != 'multipart/form-data':
       raise ValueError(f'parse_multipart: expected media type multipart/form-data; received: {self.media_type!r}')
     body = self.read_body(max_bytes=max_bytes)
-    result:dict[str,list[str|UploadedFile]] = {}
+    result:dict[str,MultipartVal|list[MultipartVal]] = {}
+
 
     def on_field(field:Field) -> None:
       if field.field_name is None: raise BadRequestError('parse_multipart: field part missing name parameter')
       key = decode_or_bad_request(field.field_name, desc='parse_multipart: field name')
       val = decode_or_bad_request(field.value or b'', desc='parse_multipart: field value')
-      result.setdefault(key, []).append(val)
+      _add_to_param_dict(result, key, val)
 
     def on_file(file:File) -> None:
       if file.field_name is None: raise BadRequestError('parse_multipart: file part missing name parameter')
       file.file_object.seek(0)
       key = decode_or_bad_request(file.field_name, desc='parse_multipart: file field name')
       filename = decode_or_bad_request(file.file_name or b'', desc='parse_multipart: file name')
-      result.setdefault(key, []).append(UploadedFile(
+      if filename == '': return
+      _add_to_param_dict(result, key, UploadedFile(
         field_name=key,
         filename=filename,
         data=file.file_object.read(),
@@ -183,12 +190,16 @@ class Request:
     return result
 
 
-  def parse_urlencoded(self, max_bytes:int) -> dict[str,list[str]]:
+  def parse_urlencoded(self, max_bytes:int) -> dict[str, str|list[str]]:
     '''Parse an application/x-www-form-urlencoded body.'''
     if self.media_type != 'application/x-www-form-urlencoded':
       raise ValueError(f'parse_urlencoded: expected media type application/x-www-form-urlencoded; received: {self.media_type!r}')
     body = self.read_body(max_bytes=max_bytes)
-    return parse_qs(decode_or_bad_request(body, desc='parse_urlencoded: body'), keep_blank_values=True)
+    parsed_list = parse_qsl(decode_or_bad_request(body, desc='parse_urlencoded: body'), keep_blank_values=True)
+    result:dict[str, str|list[str]] = {}
+    for (k, v) in parsed_list:
+      _add_to_param_dict(result, k, v)
+    return result
 
 
   def parse_json(self, max_bytes:int) -> Json:

--- a/pithy_/pithy/web/request.ut.py
+++ b/pithy_/pithy/web/request.ut.py
@@ -1,0 +1,172 @@
+# Dedicated to the public domain under CC0: https://creativecommons.org/publicdomain/zero/1.0/.
+
+from http import HTTPStatus
+
+from pithy.web.errors import BadRequestError, ResponseError
+from pithy.web.request import _add_to_param_dict, Request, UploadedFile
+from pithy.web.requestconn import BytesConn
+from utest import utest_exc, utest_run, utest_val
+
+
+def _make_request(media_type:str='', body:bytes=b'') -> Request:
+  headers:dict[str,str] = {}
+  if media_type:
+    headers['content-type'] = media_type
+  content_length = len(body) if body else None
+  conn = BytesConn(body) if body else None
+  return Request(method='GET', scheme='http', host='localhost', port=80, path='/', query_str='',
+    headers=headers, client_addr=('127.0.0.1', 0), content_length=content_length, conn=conn)
+
+
+def _make_multipart(boundary:str, *parts:bytes) -> bytes:
+  b = boundary.encode()
+  body = b''
+  for part in parts:
+    body += b'--' + b + b'\r\n' + part + b'\r\n'
+  body += b'--' + b + b'--\r\n'
+  return body
+
+
+# _add_to_param_dict
+
+@utest_run
+def _() -> None:
+  '_add_to_param_dict: first value stored as scalar.'
+  d:dict = {}
+  _add_to_param_dict(d, 'k', 'a')
+  utest_val('a', d['k'])
+
+
+@utest_run
+def _() -> None:
+  '_add_to_param_dict: second value with same key promotes to list.'
+  d:dict = {}
+  _add_to_param_dict(d, 'k', 'a')
+  _add_to_param_dict(d, 'k', 'b')
+  utest_val(['a', 'b'], d['k'])
+
+
+@utest_run
+def _() -> None:
+  '_add_to_param_dict: third value appends to existing list.'
+  d:dict = {}
+  _add_to_param_dict(d, 'k', 'a')
+  _add_to_param_dict(d, 'k', 'b')
+  _add_to_param_dict(d, 'k', 'c')
+  utest_val(['a', 'b', 'c'], d['k'])
+
+
+@utest_run
+def _() -> None:
+  '_add_to_param_dict: different keys stay independent.'
+  d:dict = {}
+  _add_to_param_dict(d, 'x', '1')
+  _add_to_param_dict(d, 'y', '2')
+  _add_to_param_dict(d, 'x', '3')
+  utest_val(['1', '3'], d['x'])
+  utest_val('2', d['y'])
+
+
+# parse_urlencoded
+
+@utest_run
+def _() -> None:
+  'parse_urlencoded: simple key/value pairs parse correctly.'
+  req = _make_request('application/x-www-form-urlencoded', b'name=alice&count=3')
+  utest_val({'name': 'alice', 'count': '3'}, req.parse_urlencoded(max_bytes=1024))
+
+
+@utest_run
+def _() -> None:
+  'parse_urlencoded: multi-value same key produces a list.'
+  req = _make_request('application/x-www-form-urlencoded', b'tag=a&tag=b&tag=c')
+  utest_val({'tag': ['a', 'b', 'c']}, req.parse_urlencoded(max_bytes=1024))
+
+
+@utest_run
+def _() -> None:
+  'parse_urlencoded: bad encoding raises BadRequestError.'
+  req = _make_request('application/x-www-form-urlencoded', b'\x80\x81')
+  utest_exc(BadRequestError, req.parse_urlencoded, max_bytes=1024)
+
+
+# parse_json / body_params JSON path
+
+@utest_run
+def _() -> None:
+  'body_params: valid JSON object with string values parses correctly.'
+  req = _make_request('application/json', b'{"name":"alice","tag":"admin"}')
+  utest_val({'name': 'alice', 'tag': 'admin'}, req.body_params(max_bytes=1024))
+
+
+@utest_run
+def _() -> None:
+  'body_params: non-object JSON raises BadRequestError.'
+  req = _make_request('application/json', b'["a","b"]')
+  utest_exc(BadRequestError, req.body_params, max_bytes=1024)
+
+
+@utest_run
+def _() -> None:
+  'body_params: JSON object with non-string value raises BadRequestError.'
+  req = _make_request('application/json', b'{"count":3}')
+  utest_exc(BadRequestError, req.body_params, max_bytes=1024)
+
+
+# parse_multipart
+
+@utest_run
+def _() -> None:
+  'parse_multipart: text field parses correctly.'
+  boundary = 'boundary123'
+  part = b'Content-Disposition: form-data; name="name"\r\n\r\nalice'
+  body = _make_multipart(boundary, part)
+  req = _make_request(f'multipart/form-data; boundary={boundary}', body)
+  utest_val({'name': 'alice'}, req.parse_multipart(max_bytes=4096))
+
+
+@utest_run
+def _() -> None:
+  'parse_multipart: file upload produces UploadedFile with correct fields.'
+  boundary = 'boundary123'
+  part = b'Content-Disposition: form-data; name="upload"; filename="test.txt"\r\nContent-Type: application/octet-stream\r\n\r\nhello'
+  body = _make_multipart(boundary, part)
+  req = _make_request(f'multipart/form-data; boundary={boundary}', body)
+  result = req.parse_multipart(max_bytes=4096)
+  f = result['upload']
+  assert isinstance(f, UploadedFile)
+  utest_val('upload', f.field_name)
+  utest_val('test.txt', f.filename)
+  utest_val(b'hello', f.data)
+
+
+@utest_run
+def _() -> None:
+  'parse_multipart: file part with empty filename is skipped.'
+  boundary = 'boundary123'
+  part = b'Content-Disposition: form-data; name="upload"; filename=""\r\nContent-Type: application/octet-stream\r\n\r\nhello'
+  body = _make_multipart(boundary, part)
+  req = _make_request(f'multipart/form-data; boundary={boundary}', body)
+  utest_val({}, req.parse_multipart(max_bytes=4096))
+
+
+@utest_run
+def _() -> None:
+  'parse_multipart: multi-value text field produces a list.'
+  boundary = 'boundary123'
+  part_a = b'Content-Disposition: form-data; name="tag"\r\n\r\nalpha'
+  part_b = b'Content-Disposition: form-data; name="tag"\r\n\r\nbeta'
+  body = _make_multipart(boundary, part_a, part_b)
+  req = _make_request(f'multipart/form-data; boundary={boundary}', body)
+  utest_val({'tag': ['alpha', 'beta']}, req.parse_multipart(max_bytes=4096))
+
+
+# body_params dispatch
+
+@utest_run
+def _() -> None:
+  'body_params: unsupported media type raises ResponseError 415.'
+  req = _make_request('text/plain', b'hello')
+  try: req.body_params(max_bytes=1024)
+  except ResponseError as e: utest_val(HTTPStatus.UNSUPPORTED_MEDIA_TYPE, e.status)
+  else: assert False, 'expected ResponseError'

--- a/pithy_/pithy/web/request.ut.py
+++ b/pithy_/pithy/web/request.ut.py
@@ -106,13 +106,6 @@ def _() -> None:
   utest_exc(BadRequestError, req.body_params, max_bytes=1024)
 
 
-@utest_run
-def _() -> None:
-  'body_params: JSON object with non-string value raises BadRequestError.'
-  req = _make_request('application/json', b'{"count":3}')
-  utest_exc(BadRequestError, req.body_params, max_bytes=1024)
-
-
 # parse_multipart
 
 @utest_run


### PR DESCRIPTION
Replaces `endpoint.py`'s `_converters` / `_default_converters` mechanism with `Transtructor` as the single authority on field conversion. The old system only supported a hardcoded list of scalar types (str, int, float, bool, date, datetime, time, UploadedFile). Endpoint fields can now be any type `Transtructor` handles: nested dataclasses, arbitrary list[T], dict[K,V], etc.

Per-endpoint customization is now done via `_prefigures` (same MRO strategy as before) using the standard 3-arg prefigure signature. `_FieldInfo` removed; is_optional, is_list, and _unwrap_optional are removed since the transtructor handles union types and None natively, so dataclass no longer needed.

Also in Transtruct.py: prefigures now intercept primitive types (previously they were bypassed), and str default behavior is stricter.
